### PR TITLE
externalize the github developer app id and secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Prerequisites to Run Integration Tests
 
     Associate the developer application client id/secret with webapp. This should be a developer app that has a callback url
     configured to work with the testing environment, e.g., http://localhost:8080/katapult/api/github/callback.
-    Before building the katapult.war, configure the `GITHUB_DEV_APP_CLIENT_ID` and `GITHUB_DEV_APP_SECRET` environment variables
-    to contain the id and secret for the github developer application you want to use.
+    Configure the `GITHUB_DEV_APP_CLIENT_ID` and `GITHUB_DEV_APP_SECRET` environment variables
+    to contain the id and secret for the github developer application you want to use. You can also specify system properties
+    of the same name to override any environment variable setting.
     
 2. A locally-running instance of OpenShift 
 
@@ -63,22 +64,3 @@ Run the Integration Tests, Optionally Building
     * Run the integration tests and have Maven skip start/stop of the WildFly server by using the `server-remote` profile.  This may speed up your development cycle if you're doing many runs by starting your server on your own and letting it run through several test runs.
         * `$ mvn integration-test -Pit,server-remote` or `$ mvn clean install -Pit,server-remote`
         
-
-Production Setup of Widfly
---------------------------
-
-When deploying the katapult.ear to the production environment, you need to override the developer application client id/secret
-encoded in the application web.xml with one that has a callback URL that is approriate for the production environment, e.g.,
-http://developers.redhat.com/api/github/callback. To do this, you need to setup the server JNDI environment to have
-java:global/GITHUB_DEV_APP_CLIENT_ID and java:global/GITHUB_DEV_APP_SECRET bindings. For wildfly, this can be done by adding
-bindings to the naming subsystem. An example standalone.xml fragment would be:
-
-```
-        <subsystem xmlns="urn:jboss:domain:naming:2.0">
-            <bindings>
-                <simple name="java:global/GITHUB_DEV_APP_CLIENT_ID" value="abc" type="java.lang.String" />
-                <simple name="java:global/GITHUB_DEV_APP_SECRET" value="xyz" type="java.lang.String" />
-            </bindings>
-            <remote-naming/>
-        </subsystem>
-```

--- a/README.md
+++ b/README.md
@@ -25,22 +25,10 @@ Prerequisites to Run Integration Tests
 
         $ echo $GITHUB_USERNAME
 
-    Associate the developer application client id/secret with webapp.
-        Edit `web/src/main/webapp/WEB-INF/web.xml` to configure the `GITHUB_CLIENT_ID` and `CLIENT_SECRET` entries:
-    
-    ```
-      <env-entry>  
-        <env-entry-name>java:global/GITHUB_CLIENT_ID</env-entry-name>
-        <env-entry-type>java.lang.String</env-entry-type>
-        <env-entry-value>***</env-entry-value>
-      </env-entry>
-      
-      <env-entry>
-        <env-entry-name>java:global/CLIENT_SECRET</env-entry-name>
-        <env-entry-type>java.lang.String</env-entry-type>
-        <env-entry-value>***</env-entry-value>
-      </env-entry>
-    ```
+    Associate the developer application client id/secret with webapp. This should be a developer app that has a callback url
+    configured to work with the testing environment, e.g., http://localhost:8080/katapult/api/github/callback.
+    Before building the katapult.war, configure the `GITHUB_DEV_APP_CLIENT_ID` and `GITHUB_DEV_APP_SECRET` environment variables
+    to contain the id and secret for the github developer application you want to use.
     
 2. A locally-running instance of OpenShift 
 
@@ -75,3 +63,22 @@ Run the Integration Tests, Optionally Building
     * Run the integration tests and have Maven skip start/stop of the WildFly server by using the `server-remote` profile.  This may speed up your development cycle if you're doing many runs by starting your server on your own and letting it run through several test runs.
         * `$ mvn integration-test -Pit,server-remote` or `$ mvn clean install -Pit,server-remote`
         
+
+Production Setup of Widfly
+--------------------------
+
+When deploying the katapult.ear to the production environment, you need to override the developer application client id/secret
+encoded in the application web.xml with one that has a callback URL that is approriate for the production environment, e.g.,
+http://developers.redhat.com/api/github/callback. To do this, you need to setup the server JNDI environment to have
+java:global/GITHUB_DEV_APP_CLIENT_ID and java:global/GITHUB_DEV_APP_SECRET bindings. For wildfly, this can be done by adding
+bindings to the naming subsystem. An example standalone.xml fragment would be:
+
+```
+        <subsystem xmlns="urn:jboss:domain:naming:2.0">
+            <bindings>
+                <simple name="java:global/GITHUB_DEV_APP_CLIENT_ID" value="abc" type="java.lang.String" />
+                <simple name="java:global/GITHUB_DEV_APP_SECRET" value="xyz" type="java.lang.String" />
+            </bindings>
+            <remote-naming/>
+        </subsystem>
+```

--- a/services/github-service/src/main/java/org/rhd/katapult/github/GithubResource.java
+++ b/services/github-service/src/main/java/org/rhd/katapult/github/GithubResource.java
@@ -14,13 +14,10 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.annotation.PostConstruct;
-import javax.annotation.Resource;
 import javax.enterprise.context.ApplicationScoped;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -62,33 +59,22 @@ public class GithubResource
    /** The client secret received from GitHub when the developer app was registered */
    private static String GITHUB_DEV_APP_SECRET;
 
-   private static String lookup(String name, String defaultValue) {
-      String value = defaultValue;
-      try {
-         InitialContext ctx = new InitialContext();
-         value = (String) ctx.lookup(name);
-      } catch (NamingException e) {
-      }
-      return value;
-   }
-
    /**
-    * Initialize the GITHUB_DEV_APP_CLIENT_ID and GITHUB_DEV_APP_SECRET values from the JNDI environment by first looking
-    * to the java:global context for an application server specific setting, and then the java:comp/env context for the
-    * web application settings encoded in the build environment.
+    * Initialize the GITHUB_DEV_APP_CLIENT_ID and GITHUB_DEV_APP_SECRET values from the environment by first looking
+    * to the system property by the same name, will fallback to the environment variable by the same name.
     */
    @PostConstruct
    private void init() {
-      // Try global context first as this would be configured at the app server level
-      GITHUB_DEV_APP_CLIENT_ID = lookup("java:global/GITHUB_DEV_APP_CLIENT_ID", null);
+      // Try the system property first since this can be specified in the server configuration
+      GITHUB_DEV_APP_CLIENT_ID = System.getProperty("GITHUB_DEV_APP_CLIENT_ID");
       if(GITHUB_DEV_APP_CLIENT_ID == null)
-         GITHUB_DEV_APP_CLIENT_ID = lookup("java:comp/env/GITHUB_DEV_APP_CLIENT_ID", null);
+         GITHUB_DEV_APP_CLIENT_ID = System.getenv("GITHUB_DEV_APP_CLIENT_ID");
       if(GITHUB_DEV_APP_CLIENT_ID == null)
          log.severe("Failed to find binding for GITHUB_DEV_APP_CLIENT_ID");
 
-      GITHUB_DEV_APP_SECRET = lookup("java:global/GITHUB_DEV_APP_SECRET", null);
+      GITHUB_DEV_APP_SECRET = System.getProperty("GITHUB_DEV_APP_SECRET");
       if(GITHUB_DEV_APP_SECRET == null)
-         GITHUB_DEV_APP_SECRET = lookup("java:comp/env/GITHUB_DEV_APP_SECRET", null);
+         GITHUB_DEV_APP_SECRET = System.getenv("GITHUB_DEV_APP_SECRET");
       if(GITHUB_DEV_APP_SECRET == null)
          log.severe("Failed to find binding for GITHUB_DEV_APP_SECRET");
    }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -17,6 +17,7 @@
             <artifactId>maven-war-plugin</artifactId>
             <configuration>
                <failOnMissingWebXml>false</failOnMissingWebXml>
+               <filteringDeploymentDescriptors>true</filteringDeploymentDescriptors>
             </configuration>
          </plugin>
       </plugins>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -8,15 +8,15 @@
 
   <env-entry>
     <description>The client id assigned to the developer github application</description>
-    <env-entry-name>java:global/GITHUB_CLIENT_ID</env-entry-name>
+    <env-entry-name>GITHUB_DEV_APP_CLIENT_ID</env-entry-name>
     <env-entry-type>java.lang.String</env-entry-type>
-    <env-entry-value>c3c3ec74379823dea3d7</env-entry-value>
+    <env-entry-value>${env.GITHUB_DEV_APP_CLIENT_ID}</env-entry-value>
   </env-entry>
   <env-entry>
     <description>The client secret assigned to the developer github application</description>
-    <env-entry-name>java:global/CLIENT_SECRET</env-entry-name>
+    <env-entry-name>GITHUB_DEV_APP_SECRET</env-entry-name>
     <env-entry-type>java.lang.String</env-entry-type>
-    <env-entry-value>284d925b55ab7e3931ea6b4325e0e6fbbf3c532b</env-entry-value>
+    <env-entry-value>${env.GITHUB_DEV_APP_SECRET}</env-entry-value>
   </env-entry>
 
 </web-app>

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -6,17 +6,4 @@
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
          metadata-complete="false">
 
-  <env-entry>
-    <description>The client id assigned to the developer github application</description>
-    <env-entry-name>GITHUB_DEV_APP_CLIENT_ID</env-entry-name>
-    <env-entry-type>java.lang.String</env-entry-type>
-    <env-entry-value>${env.GITHUB_DEV_APP_CLIENT_ID}</env-entry-value>
-  </env-entry>
-  <env-entry>
-    <description>The client secret assigned to the developer github application</description>
-    <env-entry-name>GITHUB_DEV_APP_SECRET</env-entry-name>
-    <env-entry-type>java.lang.String</env-entry-type>
-    <env-entry-value>${env.GITHUB_DEV_APP_SECRET}</env-entry-value>
-  </env-entry>
-
 </web-app>


### PR DESCRIPTION
Here is a candidate change to properly externalize the github dev app id and secret, for #27. Because of how the callback url in the dev app is part of its configuration, we will need two types of dev apps, those with callback urls appropriate for testing and those with callback urls for the production deployment. The README documents the setup of two additional GITHUB_DEV_APP_CLIENT_ID and GITHUB_DEV_APP_SECRET environment variables that should be assigned a test environment type of developer app. We should have a tooling developer app with a callback url of http://localhost:8080/katapult/api/github/callback that org developers can use for testing.

We will need another production github developer app with the appropriate callback url as well.
