### PR TITLE
Ensure GitHub OAuth WebFlow works with 2-factor authentication #26

### DIFF
--- a/tests/src/test/java/org/rhd/katapult/test/services/GithubResourceIT.java
+++ b/tests/src/test/java/org/rhd/katapult/test/services/GithubResourceIT.java
@@ -1,14 +1,20 @@
 package org.rhd.katapult.test.services;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.List;
+
+import javax.swing.*;
 
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebResponse;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
@@ -23,6 +29,9 @@ import org.junit.runner.RunWith;
 
 /**
  * Validation of the GithubResource api endpoint
+ * This requires the following environment variables to be configure:
+ * GITHUB_USERNAME
+ * GITHUB_PASSWORD
  */
 @RunWith(Arquillian.class)
 public class GithubResourceIT {
@@ -61,6 +70,9 @@ public class GithubResourceIT {
         // First need to login user into github
         String username = System.getenv("GITHUB_USERNAME");
         String password = System.getenv("GITHUB_PASSWORD");
+        if(username == null || password == null)
+            throw new IOException("GITHUB_USERNAME and GITHUB_PASSWORD must be configured for this test");
+
         HtmlInput loginField = page.getElementById("login_field", false);
         HtmlInput passwordField = page.getElementById("password", false);
         HtmlInput commitBtn = page.getElementByName("commit");
@@ -71,7 +83,10 @@ public class GithubResourceIT {
         html = page2.asXml();
         System.out.printf("\nPage#2(submit=%s; status=%d) html: %s\n", postParams, page2.getWebResponse().getStatusCode(), html);
 
-        // See if we need to authorize our github app
+        // See if two-factor auth is enabled
+        page2 = checkForTwoFactorAuth(page2);
+
+        // See if we need to authorize our github OAuth app
         try {
             HtmlButton authorizeBtn = page2.getElementByName("authorize");
             HtmlPage nextPage = authorizeBtn.click();
@@ -79,7 +94,7 @@ public class GithubResourceIT {
             System.out.printf("\nPage#3(submit=%s; status=%d) html: %s\n", postParams, nextPage.getWebResponse().getStatusCode(), html);
             page2 = nextPage;
         } catch (ElementNotFoundException e) {
-            System.err.printf("No authorize found on page2, checking for repo fork...\n");
+            System.err.printf("No OAuth app authorize found on page, checking for repo fork...\n");
         }
 
         // Validate that we landed on the users fork of jboss-eap-quickstarts
@@ -90,5 +105,48 @@ public class GithubResourceIT {
         } else {
             throw new IllegalStateException("Title, expected: "+expected+", actual: "+title);
         }
+    }
+
+    private HtmlPage checkForTwoFactorAuth(HtmlPage page2) throws IOException {
+        HtmlPage returnPage = page2;
+        /* See if two factor auth is enabled by looking for the one time password field. The page does not name the form
+        or submit button for the otp code, so we have to find it by locating the form with an action="/sessions/two-factor"
+        */
+        try {
+            List<HtmlForm> forms = page2.getForms();
+            HtmlForm theForm = null;
+            for (HtmlForm form : forms) {
+                String action = form.getActionAttribute();
+                if (action.equals("/sessions/two-factor")) {
+                    theForm = form;
+                    break;
+                }
+            }
+            if (theForm != null) {
+                HtmlInput otp = theForm.getInputByName("otp");
+                List<HtmlElement> buttons = theForm.getElementsByTagName("button");
+                HtmlButton submitBtn = null;
+                for (HtmlElement button : buttons) {
+                    HtmlButton b = (HtmlButton) button;
+                    if (b.getTypeAttribute().equalsIgnoreCase("submit")) {
+                        submitBtn = b;
+                        break;
+                    }
+                }
+                // Yes, prompt for the otp
+                String code = JOptionPane.showInputDialog(
+                        null, "Enter your two-factor one time password/code: ",
+                        "two-factor code",
+                        JOptionPane.PLAIN_MESSAGE);
+                otp.type(code);
+                returnPage = submitBtn.click();
+            } else {
+                System.out.printf("No two-factor form found\n");
+            }
+        } catch (ElementNotFoundException e) {
+            // No, go on to verifying the page is the expected jboss-eap-quickstarts fork
+            System.out.printf("No otp field indicating two-factor auth enabled\n");
+        }
+        return returnPage;
     }
 }


### PR DESCRIPTION
So it turns out that we can conditionally validate if the github user has two factor auth enabled by digging through the first login page, and then prompt the user via a swing dialog for their code. This update allows the test to be used with either standard or two factor authorization.